### PR TITLE
Configure the minimum level for events passed through the sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ The format of events to the console can be modified using the `outputTemplate` c
 ```csharp
     .WriteTo.Spectre(outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {Message:lj}{NewLine}{Exception}")
 ```
+
+The sink configuration also supports the `restrictedToMinimumLevel` and `levelSwitch` parameters:
+
+```csharp
+    .WriteTo.Spectre(restrictedToMinimumLevel: LogEventLevel.Warning)
+    .WriteTo.Spectre(levelSwitch: new LoggingLevelSwitch(LogEventLevel.Warning))
+```
+
 The sink can also be configured via `appsettings.json` using the [_Microsoft.Extensions.Configuration_](https://github.com/serilog/serilog-settings-configuration) package:
 
 ```json

--- a/src/Serilog.Sinks.Spectre/Serilog.Sinks.Spectre.csproj
+++ b/src/Serilog.Sinks.Spectre/Serilog.Sinks.Spectre.csproj
@@ -9,7 +9,7 @@
     <PackageDescription>C# Serilog sink for Spectre.Console</PackageDescription>
     <PackageProjectUrl>https://github.com/lucadecamillis/serilog-sinks-spectre</PackageProjectUrl>
     <RepositoryUrl>https://github.com/lucadecamillis/serilog-sinks-spectre</RepositoryUrl>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DebugSymbols>true</DebugSymbols>

--- a/src/Serilog.Sinks.Spectre/SpectreConsoleSinkExtensions.cs
+++ b/src/Serilog.Sinks.Spectre/SpectreConsoleSinkExtensions.cs
@@ -1,6 +1,6 @@
-using System;
-using Serilog;
 using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace Serilog.Sinks.Spectre
 {
@@ -8,11 +8,24 @@ namespace Serilog.Sinks.Spectre
 	{
 		const string DefaultConsoleOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}";
 
+		/// <summary>
+		/// Write log events to the console using Spectre.Console.
+		/// </summary>
+		/// <param name="loggerConfiguration">Logger sink configuration.</param>
+		/// <param name="outputTemplate">A message template describing the format used to write to the sink.
+		/// The default is "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}".</param>
+		/// <param name="restrictedToMinimumLevel">The minimum level for
+		/// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+		/// <param name="levelSwitch">A switch allowing the pass-through minimum level
+		/// to be changed at runtime.</param>
+		/// <returns>Configuration object allowing method chaining.</returns>
 		public static LoggerConfiguration Spectre(
 			this LoggerSinkConfiguration loggerConfiguration,
-			string outputTemplate = DefaultConsoleOutputTemplate)
+			string outputTemplate = DefaultConsoleOutputTemplate,
+			LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+			LoggingLevelSwitch levelSwitch = null)
 		{
-			return loggerConfiguration.Sink(new SpectreConsoleSink(outputTemplate));
+			return loggerConfiguration.Sink(new SpectreConsoleSink(outputTemplate), restrictedToMinimumLevel, levelSwitch);
 		}
 	}
 }


### PR DESCRIPTION
Added support for the `restrictedToMinimumLevel` and `levelSwitch` parameters to the sink configuration:

```csharp
    .WriteTo.Spectre(restrictedToMinimumLevel: LogEventLevel.Warning)
    .WriteTo.Spectre(levelSwitch: new LoggingLevelSwitch(LogEventLevel.Warning))
```

This allows to [override the minimum log level for the sink](https://github.com/serilog/serilog/wiki/Configuration-Basics#overriding-per-sink), which can be useful when multiple are in use.

```json
{
    "Serilog": {
        "MinimumLevel": "Debug",
        "WriteTo": [
            {
                "Name": "File",
                "Args": {
                    "path": "log.txt"
                }
            },
            {
                "Name": "Spectre",
                "Args": {
                    "restrictedToMinimumLevel": "Warning"
                }
            }
        ]
    }
}
```

In this example Debug logs will be written to the **File**-sink, while only Warning level logs and higher will be written to the **Spectre**-sink.