### PR TITLE
Package updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore "src/Serilog.Sinks.Spectre"
     - name: Build

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     
     - name: Build solution and generate NuGet package
       run: dotnet pack "src/Serilog.Sinks.Spectre" -c Release -o out

--- a/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
+++ b/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
+++ b/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Spectre.Console" Version="0.42.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.20" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.20" />

--- a/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
+++ b/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
-    <PackageReference Include="Spectre.Console" Version="0.42.0" />
+    <PackageReference Include="Spectre.Console" Version="0.46.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
+++ b/src/Serilog.Sinks.Spectre.Demo/Serilog.Sinks.Spectre.Demo.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Spectre.Console" Version="0.42.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.20" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.Spectre/Extensions/RenderableCollection.cs
+++ b/src/Serilog.Sinks.Spectre/Extensions/RenderableCollection.cs
@@ -16,15 +16,15 @@ namespace Serilog.Sinks.Spectre.Extensions
 			this.items = items;
 		}
 
-		public Measurement Measure(RenderContext context, int maxWidth)
+		public Measurement Measure(RenderOptions options, int maxWidth)
 		{
 			// Not used here
 			return new Measurement();
 		}
 
-		public IEnumerable<Segment> Render(RenderContext context, int maxWidth)
+		public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
 		{
-			foreach (Segment segment in this.items.SelectMany(i => i.Render(context, maxWidth)))
+			foreach (Segment segment in this.items.SelectMany(i => i.Render(options, maxWidth)))
 			{
 				yield return segment;
 			}

--- a/src/Serilog.Sinks.Spectre/Serilog.Sinks.Spectre.csproj
+++ b/src/Serilog.Sinks.Spectre/Serilog.Sinks.Spectre.csproj
@@ -20,6 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Spectre.Console" Version="0.42.0" />
+    <PackageReference Include="Spectre.Console" Version="0.46.0" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.Spectre/Serilog.Sinks.Spectre.csproj
+++ b/src/Serilog.Sinks.Spectre/Serilog.Sinks.Spectre.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Spectre.Console" Version="0.42.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the dotnet, Serilog and Spectre.Console versions. With updating the Spectre.Console update, changes to the src/Serilog.Sinks.Spectre/Extensions/RenderableCollection.cs file was necessary (I kept it basic).