### PR TITLE
Adding support for inline markup in log messages

### DIFF
--- a/src/Serilog.Sinks.Spectre/Renderers/MessageTemplateOutputTokenRenderer.cs
+++ b/src/Serilog.Sinks.Spectre/Renderers/MessageTemplateOutputTokenRenderer.cs
@@ -22,8 +22,8 @@ namespace Serilog.Sinks.Spectre.Renderers
 			{
 				if (token is TextToken t)
 				{
-					// Render text
-					yield return new Text(t.Text, global::Spectre.Console.Style.Plain);
+					// Render message as markup
+					yield return new Markup(t.Text);
 				}
 
 				if (token is PropertyToken p)


### PR DESCRIPTION
As per issue #3 inline markup in the log message text is not rendered correctly and currently appears as follows
![image](https://user-images.githubusercontent.com/8241830/233229746-4074d1b4-b875-4a1c-a113-584c08fd2bdf.png)

This pull request fixes this and the demo project now outputs inline markup correctly
![image](https://user-images.githubusercontent.com/8241830/233229799-c99c799d-07ff-4e94-b9e7-04cc62b5fd01.png)
